### PR TITLE
Add Pong Game Engine & Rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/public/index.html
+++ b/public/index.html
@@ -95,14 +95,14 @@
 			 * @param {AppNode} node
 			 * @param {XY_Adjustment} xyadj
 			 * @param {boolean} check_node_collide
-			 * @returns {{c: "MOVED"} | {c: "OUT_OF_BOUNDS" | "NODE_COLLISION", reason: CollisionReason}}
+			 * @returns {{c: "MOVED"} | {c: "OUT_OF_BOUNDS", reason: CollisionReason} | {c: "NODE_COLLISION",  detail: NodeCollisionDetail }}
 			 **/
 			function move_node(node, xyadj) {
 				let m_outofbounds = will_bounds_collide(node, xyadj);
 				if(m_outofbounds.c == "NO") {
 					let m_node_collision = node.node_collides ? will_node_collide(node, xyadj) : {c: /**@type{"NO"}*/("NO")};
 					if(m_node_collision.c == "YES") {
-						return {c: "NODE_COLLISION", reason: m_node_collision.reason};
+						return {c: "NODE_COLLISION", detail: m_node_collision.detail};
 					}
 					node.x += (xyadj.x ?? 0);
 					node.y += (xyadj.y ?? 0);
@@ -132,7 +132,13 @@
 			 * @param {XY_Adjustment} xyadj
 			 * @param {CollisionReason} collision_reason
 			 * */
-			function bounce(node, xyadj, collision_reason) {
+			function bounce(node, collision_reason) {
+				let xyadj = NodeUtil.get_vel_xy(node);
+				let new_x = collision_reason == "BOTH" || collision_reason == "X" ? -xyadj.x : xyadj.x,
+					new_y = collision_reason == "BOTH" || collision_reason == "Y" ? -xyadj.y : xyadj.y;
+				let new_velocity = {x: new_x, y: new_y};
+				return {move_result: move_node(node, new_velocity), new_velocity};
+			}
 				let new_x = collision_reason == "BOTH" || collision_reason == "X" ? -xyadj.x : xyadj.x,
 					new_y = collision_reason == "BOTH" || collision_reason == "Y" ? -xyadj.y : xyadj.y;
 				let new_velocity = {x: new_x, y: new_y};

--- a/public/index.html
+++ b/public/index.html
@@ -475,10 +475,16 @@
 			let ball_n = app.getNode(Game.Ball.node_name);
 			let m_ball_move = NodeUtil.process_velocity(ball_n, true);
 			if(m_ball_move.c == "NODE_COLLISION"){
-				let {new_velocity} = NodeUtil.bounce(ball_n, NodeUtil.get_vel_xy(ball_n), m_ball_move.reason);
+				let {new_velocity} = NodeUtil.bounce_hard(ball_n, m_ball_move.detail);
 				NodeUtil.set_xy_vel(ball_n, new_velocity);
 			}else if(m_ball_move.c == "OUT_OF_BOUNDS") {
-				Game.reset_ball_position();
+				if(m_ball_move.reason == "Y") {
+					let {new_velocity} = NodeUtil.bounce(ball_n, m_ball_move.reason);
+					NodeUtil.set_xy_vel(ball_n, new_velocity);
+				}else{
+					// Point
+					Game.reset_ball_position(this);
+				}
 			}
 
 		};

--- a/public/index.html
+++ b/public/index.html
@@ -274,7 +274,32 @@
 
 		var Game = {
 			Settings: {
-				info_text_fl: "info-text"
+				// Seems optimal for 1024x768
+				speed: {players:10, ball: 8},
+				info_text_fl: "info-text",
+				x_bounce_bias: 10
+			},
+			/**@param {{width: number, height: number}} new_resolution
+			*/
+			settings_for_resolution(new_resolution) {
+
+				// Width determines the speed. Height determines the bounce bias.
+				// These settings work very well on 1024x768.
+				const base_speed = {players: 10, ball: 8}, base_bias = 10, base_width = 1024, base_height = 768;
+				
+				const speed_shift = Math.floor(10*new_resolution.width/base_width)/10;
+				const speed = {players: base_speed.players * speed_shift, ball: base_speed.ball*speed_shift};
+				const bias_shift = Math.floor(10*base_height/new_resolution.height)/10;
+				const x_bounce_bias = base_bias * bias_shift;
+				return {speed, x_bounce_bias};
+			},
+			reload_res_settings(app) {
+				const {height, width} = app;
+				let {speed, x_bounce_bias} = Game.settings_for_resolution({height, width});
+				Game.Settings.speed = speed;
+				Game.Settings.x_bounce_bias = x_bounce_bias;
+				Game.reset_all_positions(app);
+				Game.reset_ball_velocity(app);
 			},
 			/**@type{Player}*/
 			PlayerLeft: {
@@ -326,7 +351,7 @@
 				app.clear();
 				// Simplest way is to have the game reset the round and halt.
 				// When called during initial setup, this effectively does nothing, which is what we want.
-				Game.reset_all_positions(app);
+				Game.reload_res_settings(app);
 				app.pause("Game Resized. Press Space.")
 			},
 			reset_player_positions(app) {
@@ -344,6 +369,12 @@
 				let half_r = 0.5*ball_n.radius;
 				ball_n.x = (0.5*app.width) - half_r;
 				ball_n.y = (0.5*app.height) - half_r;
+			},
+			reset_ball_velocity(app) {
+				let ball_n = app.getNode(Game.Ball.node_name);
+				let starting_ball_dir = Math.cos(this.timestamp / 100) > 0 ? 1 : -1;
+				ball_n.vel_x = starting_ball_dir*Game.Settings.speed.ball
+				ball_n.vel_y = 0;
 			},
 			reset_score_positions(app) {
 				let left = Game.get_player_score_floater(app, Game.PlayerLeft);
@@ -514,8 +545,6 @@
 				// vel_y: 1
 			});
 
-			let starting_ball_dir = Math.cos(this.timestamp / 100) > 0 ? 1 : -1;
-
 			this.nodes.push({
 				id: 'ball-circle',
 				x: 200,
@@ -523,9 +552,7 @@
 				shape: "Circle",
 				radius: 10,
 				color: 'green',
-				node_collides: true,
-				vel_x: starting_ball_dir*Game.Settings.speed.ball,
-				vel_y: 0
+				node_collides: true
 			});
 
 			this.floaters.push(/**@type{Floater}*/({
@@ -543,7 +570,7 @@
 				, value: "", x: 0, y: 0, hidden: true
 			}));
 
-			Game.reset_all_positions(this);
+			Game.reload_res_settings(this);
 			Game.set_info_text(this, "Start: Press Space.");
 			Game.show_info_text(this);
 		};
@@ -573,7 +600,7 @@
 				NodeUtil.set_xy_vel(ball_n, new_velocity);
 			}else if(m_ball_move.c == "OUT_OF_BOUNDS") {
 				if(m_ball_move.reason == "Y") {
-					let {new_velocity} = NodeUtil.bounce_biased(ball_n, "x", m_ball_move.reason, 10);
+					let {new_velocity} = NodeUtil.bounce_biased(ball_n, "x", m_ball_move.reason, Game.Settings.x_bounce_bias);
 					NodeUtil.set_xy_vel(ball_n, new_velocity);
 				}else{
 					// Point

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
 		/**
 		 * @typedef {{id: string, x: number, y: number, width: number
 		 * , height: number, color: string}} AppNode
-		 * @typedef {AppNode & {traj_x: number, traj_y: number}} MovingNode
+		 * @typedef {AppNode & {vel_x: number, vel_y: number}} MovingNode
 		 * */
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -515,6 +515,8 @@
 				// vel_y: 1
 			});
 
+			let starting_ball_dir = Math.cos(this.timestamp / 100) > 0 ? 1 : -1;
+
 			this.nodes.push({
 				id: 'ball-circle',
 				x: 200,
@@ -523,7 +525,7 @@
 				radius: 10,
 				color: 'green',
 				node_collides: true,
-				vel_x: 1*Game.Settings.speed.ball,
+				vel_x: starting_ball_dir*Game.Settings.speed.ball,
 				vel_y: 0
 			});
 

--- a/public/index.html
+++ b/public/index.html
@@ -57,8 +57,8 @@
 				let prop_x = node.x+(xyadj.x ?? 0), prop_y = node.y+(xyadj.y ?? 0);
 				/**@type{{width: number, height: number}}*/
 				let {width: app_x, height: app_y} = app;
-				let x_failed = (prop_x < 0 || prop_x+node.width > app_x)
-				, 	y_failed = (prop_y < 0 || prop_y+node.height > app_y);
+				let x_failed = (prop_x < 0 || prop_x+(node.width || node.radius) > app_x)
+				, 	y_failed = (prop_y < 0 || prop_y+(node.height || node.radius) > app_y);
 				return (x_failed && y_failed ? {c: "YES", reason: "BOTH"} 
 							: x_failed ? {c: "YES", reason: "X"} 
 							: y_failed ? {c: "YES", reason: "Y"} 

--- a/public/index.html
+++ b/public/index.html
@@ -325,7 +325,10 @@
 				document.getElementById("canvas").width = width;
 				app.height = height; app.width = width;
 				app.clear();
-				// TODO: adjust app nodes accordingly.
+				// Simplest way is to have the game reset the round and halt.
+				// When called during initial setup, this effectively does nothing, which is what we want.
+				Game.reset_all_positions(app);
+				app.pause("Game Resized. Press Space.")
 			},
 			reset_player_positions(app) {
 				let left = Game.get_player_node(app, Game.PlayerLeft);
@@ -388,6 +391,15 @@
 			set_info_text(app, text) {
 				Game.get_info_text_floater(app).value = text;
 			},
+			/**@param {number} ball_x */
+			handle_ball_leave_bounds(app, ball_x) {
+				/**@type {"left" | "right"}*/
+				let boundary = ball_x > app.width/2 ? "right" : "left"; 
+				let winning_player =  boundary == "right" ? Game.PlayerLeft : Game.PlayerRight;
+				winning_player.score += 1;
+				let winning_floater = Game.get_player_score_floater(app, winning_player).value = String(winning_player.score);
+				Game.reset_ball_position(app);
+				app.pause("Player "+winning_player.player_name+" scores! Press Space.");
 			},
 			get_control_request_info(control_code) {
 				var found_player, direction;
@@ -564,7 +576,7 @@
 					NodeUtil.set_xy_vel(ball_n, new_velocity);
 				}else{
 					// Point
-					Game.reset_ball_position(this);
+					Game.handle_ball_leave_bounds(this, ball_n.x);
 				}
 			}
 

--- a/public/index.html
+++ b/public/index.html
@@ -5,9 +5,21 @@
 </head>
 <body>
 	<canvas id="canvas" width="800" height="400"></canvas>
+	<style>
+		/**
+			Overflow being hidden prevents the presence of a scrollbar in a resizable, fullscreen game.
+		*/
+		body {
+			overflow: hidden;
+		}
+	</style>
+		
 	<script type="text/javascript" src="js/app.js"></script>
 	<script type="text/javascript">
-		//Sample functions, remove these functions and design ping-pong game with onInit and onUpdate.
+		// Apply a margin to the body that can be accounted for programatically.
+		const BODY_MARGIN = 10;
+		document.querySelector("body").style.margin = BODY_MARGIN+"px";
+
 
 		app.onInit = function(){
 			this.nodes.push({

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,20 @@
 		document.querySelector("body").style.margin = BODY_MARGIN+"px";
 
 
+		/** 
+		 * Adjust both the canvas and the app to resize the game.
+		 * @param {{height: number, width: number, clear: ()=>void}} app
+		 * @param {number} width
+		 * @param {number} height
+		 **/
+		function resize_game(app, height, width) {
+			document.getElementById("canvas").height = height;
+			document.getElementById("canvas").width = width;
+			app.height = height; app.width = width;
+			app.clear();
+			// TODO: adjust app nodes accordingly.
+		}
+
 		app.onInit = function(){
 			this.nodes.push({
 				id : 'red-box',

--- a/public/index.html
+++ b/public/index.html
@@ -143,9 +143,46 @@
 				let new_velocity = {x: new_x, y: new_y};
 				return {move_result: move_node(node, new_velocity), new_velocity};
 			}
-				let new_x = collision_reason == "BOTH" || collision_reason == "X" ? -xyadj.x : xyadj.x,
-					new_y = collision_reason == "BOTH" || collision_reason == "Y" ? -xyadj.y : xyadj.y;
-				let new_velocity = {x: new_x, y: new_y};
+
+			/**
+			 * A variant of bounce that biases the node toward velocity on the axis of their choice.
+			 * @param {AppNode} node
+			 * @param {"x" | "y"} bias_axis
+			 * @param {CollisionReason} collision_reason
+			 * @param {number} bias_strength -- Keep at least 5. This is the nth fraction of velocity carved away from the unbiased. i.e., 5 = 1/5.
+			 **/
+			function bounce_biased(node, bias_axis, collision_reason, bias_strength=10) {
+				const xyadj = NodeUtil.get_vel_xy(node);
+				const x_sign = xyadj.x > 0 ? "POS" : "NEG"
+					, y_sign = xyadj.y > 0 ? "POS": "NEG";
+				const flip_sign = (sign) => sign == "POS" ? "NEG" : "POS";
+				let signs = {x: x_sign, y: y_sign};
+
+				console.log({x_sign, y_sign});
+
+				if(collision_reason == "BOTH") {
+					signs.x = flip_sign(x_sign); 
+					signs.y = flip_sign(y_sign);
+				} else if (collision_reason == "X") {
+					signs.x  = flip_sign(x_sign);
+				} else {
+					signs.y = flip_sign(y_sign);
+				}
+				const absv = {
+					x: Math.abs(xyadj.x)
+				,	y: Math.abs(xyadj.y)
+				};
+				console.log(signs);
+				const total_velocity = absv.x+absv.y;
+				// Slide {bias_strength}% of the unbiased velocity over to the biased.
+				let inv_bias = bias_axis == "x" ? "y": "x";
+				let shifting_velocity = absv[inv_bias]/bias_strength;
+
+				let new_velocity = {};
+				let new_biased_velocity_absv = absv[bias_axis]+shifting_velocity;
+				new_velocity[bias_axis] = new_biased_velocity_absv*(signs[bias_axis] == "POS" ? 1 : -1);
+				new_velocity[inv_bias] = (total_velocity-new_biased_velocity_absv)*(signs[inv_bias] == "POS" ? 1 : -1);
+				console.log(new_velocity)
 				return {move_result: move_node(node, new_velocity), new_velocity};
 			}
 
@@ -172,7 +209,7 @@
 				let y_fmw = Math.ceil(100/half_rect_height*(y-half_rect_height-min_y));
 				let half_rect_width = rect_width*0.5;
 				let x_fmw = from_middle_wgt = Math.ceil(100/half_rect_width*(x-half_rect_width-min_x));
-				console.log({half_rect_height, half_rect_width, x, min_x, y, min_y, y_fmw, x_fmw});
+				// console.log({half_rect_height, half_rect_width, x, min_x, y, min_y, y_fmw, x_fmw});
 				/**@type{"Y" | "X"}*/
 				let surface = Math.abs(y_fmw) < Math.abs(x_fmw) ? "Y" : "X";
 				if(surface == "Y") {
@@ -187,12 +224,9 @@
 
 				// The 'from_middle_wgt' determines the weight that is stolen from the total velocity.
 				// Since we don't want it to completely deadpan movement, it only gets a 90% share of the velocity, max.
-				console.log({total_velocity, from_middle_wgt});
 				let surface_axis_velocity = Math.floor(0.9*total_velocity*from_middle_wgt/10)/10;
-				console.log({surface_axis_velocity})
 				// Dump the rest into the violation axis velocity & give it a flip.
 				let violation_axis_velocity = (total_velocity-Math.abs(surface_axis_velocity))*(violation_sign == "POS" ? -1 : 1);
-				console.log({violation_axis_velocity});
 
 				/**@type{{x: number, y: number}}*/
 				let new_velocity = {};
@@ -453,7 +487,7 @@
 				NodeUtil.set_xy_vel(ball_n, new_velocity);
 			}else if(m_ball_move.c == "OUT_OF_BOUNDS") {
 				if(m_ball_move.reason == "Y") {
-					let {new_velocity} = NodeUtil.bounce(ball_n, m_ball_move.reason);
+					let {new_velocity} = NodeUtil.bounce_biased(ball_n, "x", m_ball_move.reason, 10);
 					NodeUtil.set_xy_vel(ball_n, new_velocity);
 				}else{
 					// Point

--- a/public/index.html
+++ b/public/index.html
@@ -150,6 +150,91 @@
 			}
 
 			/**
+			 * Simulate 'angling' of the paddle against the ball, causing the ball to bounce more wildly.
+			 * @param {MovingNode & {shape: "Circle"}} moving_circle
+			 * @param {NodeCollisionDetail} rect_colldet -- Rectangle Collision Detail
+			*/
+			function bounce_hard(moving_circle, rect_colldet) {
+
+				let {min_x, min_y, max_x, max_y, prop_x: x, prop_y: y, other_width: rect_width, other_height: rect_height} = rect_colldet;
+
+				let total_velocity = Math.abs(moving_circle.vel_x)+Math.abs(moving_circle.vel_y);
+
+				// Most of the time, it's the y surface we're bouncing on. We determine by checking which violation is closest to the ball.
+				// The primary surface is the opposite of that violation's axis.
+				// E.g., if we're within 2 points of violating the x axis, that means we'd be striking the surface on the y axis.
+				// This only works assuming this is a collision against a rectangle.
+
+				/**@type{Array<{value: number} & {surface: "Y", violation_axis: "X"} | {surface: "X", violation_axis: "Y"}}*/
+				// let minlist = [
+				// 		{surface: "Y", violation_axis: "X", value: Math.abs(max_x-x)}
+				// 	,	{surface: "Y", violation_axis: "X", value: Math.abs(min_x-x)}
+				// 	,	{surface: "X", violation_axis: "Y", value: Math.abs(max_y-y)}
+				// 	,	{surface: "X", violation_axis: "Y", value: Math.abs(min_y-y)}
+				// ];
+
+				// "closest" here stands for "closest to the current position". We want to know where the circle is closest to.
+				// let closest = minlist.reduce((prev, curr) => curr.value < prev.value ? curr : prev);
+
+				// Determine the 'weight' for the primary surface in each direction from the middle. Ranges from -100 to 100.
+				// /**@type{number}*/
+				// let from_middle_wgt;
+				// /**@type{number}*/
+				// let violation_current_velocity;
+				// // Most common case.
+				// if(closest.surface == "Y") {
+				// 	let half_rect_height = rect_height*0.5
+				// 	console.log({half_rect_height, y, min_y});
+				// 	from_middle_wgt = Math.ceil(100/half_rect_height*(y-half_rect_height-min_y));
+				// 	violation_current_velocity = moving_circle.vel_x;
+				// } else {
+				// 	let half_rect_width = rect_width*0.5;
+				// 	console.log({half_rect_width, x, min_x});
+				// 	from_middle_wgt = Math.ceil(100/half_rect_width*(x-half_rect_width-min_x));
+				// 	violation_current_velocity = moving_circle.vel_y;
+				// }
+
+				let from_middle_wgt;
+				let half_rect_height = rect_height*0.5
+				let y_fmw = Math.ceil(100/half_rect_height*(y-half_rect_height-min_y));
+				let half_rect_width = rect_width*0.5;
+				let x_fmw = from_middle_wgt = Math.ceil(100/half_rect_width*(x-half_rect_width-min_x));
+				console.log({half_rect_height, half_rect_width, x, min_x, y, min_y, y_fmw, x_fmw});
+				/**@type{"Y" | "X"}*/
+				let surface = Math.abs(y_fmw) < Math.abs(x_fmw) ? "Y" : "X";
+				if(surface == "Y") {
+					from_middle_wgt = y_fmw;
+					violation_current_velocity = moving_circle.vel_x;
+				}else{
+					from_middle_wgt = x_fmw;
+					violation_current_velocity = moving_circle.vel_y;
+				}
+				/**@type{"POS" | "NEG" | "ZERO"}*/
+				let violation_sign = (violation_current_velocity > 0) ? "POS" : violation_current_velocity < 0 ? "NEG" : "ZERO";
+
+				// The 'from_middle_wgt' determines the weight that is stolen from the total velocity.
+				// Since we don't want it to completely deadpan movement, it only gets a 90% share of the velocity, max.
+				console.log({total_velocity, from_middle_wgt});
+				let surface_axis_velocity = Math.floor(0.9*total_velocity*from_middle_wgt/10)/10;
+				console.log({surface_axis_velocity})
+				// Dump the rest into the violation axis velocity & give it a flip.
+				let violation_axis_velocity = (total_velocity-Math.abs(surface_axis_velocity))*(violation_sign == "POS" ? -1 : 1);
+				console.log({violation_axis_velocity});
+
+				/**@type{{x: number, y: number}}*/
+				let new_velocity = {};
+
+				if(surface == "Y") {
+					new_velocity.y = surface_axis_velocity;
+					new_velocity.x = violation_axis_velocity;
+				}else{
+					new_velocity.x = surface_axis_velocity;
+					new_velocity.y = violation_axis_velocity;
+				}
+				return {move_result: move_node(moving_circle, new_velocity), new_velocity};
+			}
+
+			/**
 			 * @param {MovingNode} movode */
 			function get_velocity(movode) {
 				return {x: movode.vel_x, y: movode.vel_y};

--- a/public/index.html
+++ b/public/index.html
@@ -110,8 +110,7 @@
 			}
 
 			return {
-				will_collide_q : will_node_collide
-			,	move: move_node
+				move: move_node
 			,	bounce
 			,	process_velocity
 			,	get_vel_xy: get_velocity
@@ -125,6 +124,9 @@
 
 
 		var Game = {
+			Settings: {
+				speed: {players:3, ball: 1}
+			},
 			/**@type{Player}*/
 			PlayerLeft: {
 				node_name: "red-box"
@@ -167,6 +169,27 @@
 				app.height = height; app.width = width;
 				app.clear();
 				// TODO: adjust app nodes accordingly.
+			get_control_request_info(control_code) {
+				var found_player, direction;
+				switch(control_code) {
+					case Game.PlayerLeft.controls.Up: {
+						found_player = Game.PlayerLeft; direction = "Up"; break;
+					}
+					case Game.PlayerRight.controls.Up: {
+						found_player = Game.PlayerRight; direction = "Up"; break;
+					}
+					case Game.PlayerLeft.controls.Down: {
+						found_player = Game.PlayerLeft; direction = "Down"; break;
+					}
+					case Game.PlayerRight.controls.Down: {
+						found_player = Game.PlayerRight; direction = "Down"; break;
+					}
+				}
+				if(found_player != null) {
+					return {c: /**@type {"FOUND"}*/("FOUND"), player: found_player, direction: /**@type{"Up" | "Down"}*/(direction)}
+				}else{
+					return {c: /**@type{"NOT_FOUND"}*/("NOT_FOUND")};
+				}
 			}
 		}
 
@@ -192,38 +215,28 @@
 				if(e.code == "Space") {
 					// `this` is not the event because of how arrow functions mingle in the lexical scoping world.
 					this.toggle_pause();
-				}else if(e.code == Game.PlayerLeft.controls.Up || e.code == Game.PlayerLeft.controls.Down) {
-					let n = Game.get_player_node(this, Game.PlayerLeft);
-					NodeUtil.set_xy_vel(n, {y:0});
-				}else if(e.code == Game.PlayerRight.controls.Up || e.code == Game.PlayerRight.controls.Down) {
-					let n = Game.get_player_node(this, Game.PlayerRight);
-					NodeUtil.set_xy_vel(n, {y: 0});
+				}else{
+					let m_cri = Game.get_control_request_info(e.code);
+					if(m_cri.c == "FOUND") {
+						let n = Game.get_player_node(this, m_cri.player);
+						// We handle the case where the user has pressed on the new key to go another way but has yet
+						// to release the old key. If we don't do this, then releasing the old key interrupts the intended
+						// motion. By adding this, we make the gameplay fluid.
+						let already_going_another_way = (m_cri.direction == "Up" && n.vel_y > 0) || (m_cri.direction == "Down" && n.vel_y < 0);
+						if(already_going_another_way == false) NodeUtil.set_xy_vel(n, {y:0});
+					}
 				}
 			})
 
 			document.addEventListener("keydown", (e) => {
 				if(e.repeat) return;
-				switch(e.code) {
-					case Game.PlayerLeft.controls.Up: {
-						let n = Game.get_player_node(this, Game.PlayerLeft);
-						NodeUtil.set_xy_vel(n, {y: -1});
-						break;
-					}
-					case Game.PlayerRight.controls.Up: {
-						let n = Game.get_player_node(this, Game.PlayerRight);
-						NodeUtil.set_xy_vel(n, {y: -1});
-						break;
-					}
-					case Game.PlayerLeft.controls.Down: {
-						let n = Game.get_player_node(this, Game.PlayerLeft);
-						NodeUtil.set_xy_vel(n, {y: 1});
-						break;
-					}
-					case Game.PlayerRight.controls.Down: {
-						let n = Game.get_player_node(this, Game.PlayerRight);
-						NodeUtil.set_xy_vel(n, {y: 1});
-						break;
-					}
+				let m_cri = Game.get_control_request_info(e.code);
+
+				if(m_cri.c == "FOUND") {
+					const psf = Game.Settings.speed.players;
+					const dirnum = m_cri.direction == "Up" ? -1 : 1;
+					let n = Game.get_player_node(this, m_cri.player);
+					NodeUtil.set_xy_vel(n, {y: dirnum*psf});
 				}
 
 			})

--- a/public/index.html
+++ b/public/index.html
@@ -185,7 +185,7 @@
 				id : 'red-box',
 				x  : 100,
 				y  : 0,
-				width  : 100,
+				width  : 25,
 				height : 100,
 				color  : 'red',
 				direction : 0
@@ -195,9 +195,11 @@
 				id : 'black-box',
 				x  : 50,
 				y  : 0,
-				width  : 150,
-				height : 150,
-				color  : 'black'
+				width  : 25,
+				height : 100,
+				color  : 'black',
+				vel_x: 0.25,
+				vel_y: 1
 			});
 		};
 
@@ -209,11 +211,18 @@
 			// I could fall back to global variable assumptions (easiest, but not the best for long-term if there's more work to be done in app.onInit)
 			// or I could wrap app.onInit and app.onUpdate in its own init, but that would appear redundant at first glance. Consider this a TODO.
 			if(NodeUtil == undefined) return;
+			if(this.paused) return;
+			let black_box = this.getNode('black-box');
+			let m_bb_move = NodeUtil.process_velocity(black_box);
+			if(m_bb_move.c == "COLLIDED") {
+				let {new_velocity} = NodeUtil.bounce(black_box, NodeUtil.get_vel_xy(black_box), m_bb_move.reason);
+				NodeUtil.set_xy_vel(black_box, new_velocity);
+			}
+
 
 			/**@type {MovingNode}*/
 			let red_box = this.getNode("red-box");
-			NodeUtil.move(this.getNode('black-box'), {y: 1});
-
+			
 			if(Math.cos(this.timestamp/1000) > 0){
 				red_box.direction = -1;
 			}else{

--- a/public/index.html
+++ b/public/index.html
@@ -169,6 +169,27 @@
 				app.height = height; app.width = width;
 				app.clear();
 				// TODO: adjust app nodes accordingly.
+			},
+			reset_player_positions(app) {
+				let left = Game.get_player_node(app, Game.PlayerLeft);
+				let right = Game.get_player_node(app, Game.PlayerRight);
+				let one_segment_x = 0.125*app.width;
+				let half_y = 0.5*app.height;
+				left.x = one_segment_x;
+				right.x = app.width-one_segment_x-right.width;
+				left.y = half_y - (0.5*left.height);
+				right.y = half_y - (0.5*right.height);
+			},
+			reset_ball_position(app) {
+				let ball_n = app.getNode(Game.Ball.node_name);
+				let half_r = 0.5*ball_n.radius;
+				ball_n.x = (0.5*app.width) - half_r;
+				ball_n.y = (0.5*app.height) - half_r;
+			},
+			reset_all_positions(app) {
+				Game.reset_player_positions(app);
+				Game.reset_ball_position(app);
+			},
 			get_control_request_info(control_code) {
 				var found_player, direction;
 				switch(control_code) {
@@ -275,8 +296,8 @@
 				width  : 25,
 				height : 100,
 				color  : 'black',
-				vel_x: 0,
-				vel_y: 1
+				// vel_x: 0,
+				// vel_y: 1
 			});
 
 			this.nodes.push({
@@ -287,6 +308,8 @@
 				radius: 10,
 				color: 'green'
 			})
+
+			Game.reset_all_positions(this);
 		};
 
 		app.onUpdate = function(time){

--- a/public/index.html
+++ b/public/index.html
@@ -265,6 +265,15 @@
 				vel_x: 0,
 				vel_y: 1
 			});
+
+			this.nodes.push({
+				id: 'ball-circle',
+				x: 200,
+				y: 100,
+				shape: "Circle",
+				radius: 10,
+				color: 'green'
+			})
 		};
 
 		app.onUpdate = function(time){

--- a/public/index.html
+++ b/public/index.html
@@ -34,8 +34,29 @@
 			app.clear();
 			// TODO: adjust app nodes accordingly.
 		}
+		var build_NodeUtil = ((app) => {
+
+		});
+		/**@type{ReturnType<build_NodeUtil>}*/
+		var NodeUtil;
 
 		app.onInit = function(){
+
+			// Call to update canvas/app to new size. Declared here to lock in app as `this` to the scope.
+			// We're also only using this once elsewhere, in the below event declaration.
+			let update_size_to_viewport = () => resize_game(this, window.visualViewport.height-BODY_MARGIN, window.visualViewport.width-BODY_MARGIN);
+			update_size_to_viewport();
+			// onInit will only be called once so declaring this event here is safe.
+			window.addEventListener("resize", update_size_to_viewport);
+
+			// I recognize that I could have created this earlier by referencing `app` directly in the global scope,
+			// but here I am preparing for the possibility that I am not 'ready' until I am in an init function.
+			// Same reason I capture `this` in update_size_to_viewport.
+			// Ultimately, I build NodeUtil here because of the requirement to not touch app.js 
+			// (and by extension, safe-assumedly, not extending the app global var itself)
+			NodeUtil = build_NodeUtil(this);
+
+
 			this.nodes.push({
 				id : 'red-box',
 				x  : 100,

--- a/public/index.html
+++ b/public/index.html
@@ -31,6 +31,9 @@
 		 * , other_width: number, other_height: number}} NodeCollisionDetail
 		 * */
 
+		//Mirrored from app.js:
+		/**@typedef {{id: string, x: number, y: number, type: "text", value: string, hidden:boolean, font: string, font_px: number, color: string, align: "left" | "center" | "right"}} Floater */
+
 
 		var build_NodeUtil = ((app) => {
 

--- a/public/index.html
+++ b/public/index.html
@@ -161,7 +161,7 @@
 			/**@param {Player} player
 			 * @returns {MovingNode}
 			*/
-			get_player_node: function get_player_node(app, player) {
+			get_player_node (app, player) {
 				return app.getNode(player.node_name);
 			},
 			Ball: {

--- a/public/index.html
+++ b/public/index.html
@@ -21,8 +21,8 @@
 		document.querySelector("body").style.margin = BODY_MARGIN+"px";
 
 		/**
-		 * @typedef {{id: string, x: number, y: number, width: number
-		 * , height: number, color: string}} AppNode
+		 * @typedef {{id: string, x: number, y: number
+		 * , color: string}  & ({shape: "Rectangle", width: number, height: number} | {shape: "Circle", radius: number} )} AppNode
 		 * @typedef {AppNode & {vel_x: number, vel_y: number}} MovingNode
 		 * */
 

--- a/public/index.html
+++ b/public/index.html
@@ -292,17 +292,6 @@
 					NodeUtil.set_xy_vel(player_node, {y: 0});
 				}
 			}
-
-			/**@type {MovingNode}*/
-			let red_box = this.getNode("red-box");
-			
-			if(Math.cos(this.timestamp/1000) > 0){
-				red_box.direction = -1;
-			}else{
-				red_box.direction = 1;
-			}
-
-			NodeUtil.move(red_box, {x: red_box.direction});
 		};
 	</script>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -69,7 +69,7 @@
 			 * Attempt to move a node. Send back data for success or failure.
 			 * @param {AppNode} node
 			 * @param {XY_Adjustment} xyadj
-			 * @returns {{c: "MOVED"} | {c: "STAYED", reason: CollisionReason}}
+			 * @returns {{c: "MOVED"} | {c: "COLLIDED", reason: CollisionReason}}
 			 **/
 			function move_node(node, xyadj) {
 				let m_collision = will_node_collide(node, xyadj);
@@ -114,10 +114,21 @@
 			function get_velocity(movode) {
 				return {x: movode.vel_x, y: movode.vel_y};
 			}
+			/**
+			 * @param {MovingNode} movode 
+			 * @param {{x: number, y: number}} new_velocity */
+			function set_velocity(movode, {x,y}) {
+				movode.vel_x = x;
+				movode.vel_y = y;
 			}
+
 			return {
 				will_collide_q : will_node_collide
 			,	move: move_node
+			,	bounce
+			,	process_velocity
+			,	get_vel_xy: get_velocity
+			,	set_xy_vel: set_velocity
 			}
 		});
 		/**@type{ReturnType<build_NodeUtil>}*/

--- a/public/index.html
+++ b/public/index.html
@@ -232,7 +232,7 @@
 
 			// Call to update canvas/app to new size. Declared here to lock in app as `this` to the scope.
 			// We're also only using this once elsewhere, in the below event declaration.
-			let update_size_to_viewport = () => resize_game(this, window.visualViewport.height-BODY_MARGIN, window.visualViewport.width-BODY_MARGIN);
+			let update_size_to_viewport = () => Game.resize(this, window.visualViewport.height-BODY_MARGIN, window.visualViewport.width-BODY_MARGIN);
 			update_size_to_viewport();
 			// onInit will only be called once so declaring this event here is safe.
 			window.addEventListener("resize", update_size_to_viewport);

--- a/public/index.html
+++ b/public/index.html
@@ -45,8 +45,8 @@
 				let prop_x = node.x+(xyadj.x ?? 0), prop_y = node.y+(xyadj.y ?? 0);
 				/**@type{{width: number, height: number}}*/
 				let {width: app_x, height: app_y} = app;
-				let x_failed = (prop_x < 0 || prop_x+(node.width || node.radius) > app_x)
-				, 	y_failed = (prop_y < 0 || prop_y+(node.height || node.radius) > app_y);
+				let x_failed = (prop_x < 0 || prop_x+(node.width ?? node.radius) > app_x)
+				, 	y_failed = (prop_y < 0 || prop_y+(node.height ?? node.radius) > app_y);
 				return (x_failed && y_failed ? {c: "YES", reason: "BOTH"} 
 							: x_failed ? {c: "YES", reason: "X"} 
 							: y_failed ? {c: "YES", reason: "Y"} 

--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,10 @@
 		 * , color: string, node_collides: boolean}  
 		 * & ({shape: "Rectangle", width: number, height: number} | {shape: "Circle", radius: number} )} AppNode
 		 * @typedef {AppNode & {vel_x: number, vel_y: number}} MovingNode
+		 * @typedef {{prop_x: number, prop_y: number, prop_min_x: number
+		 * , prop_min_y: number, prop_max_x: number, prop_max_y: number
+		 * , min_x: number, min_y: number, max_x: number, max_y: number
+		 * , other_width: number, other_height: number}} NodeCollisionDetail
 		 * */
 
 
@@ -174,7 +178,7 @@
 
 		var Game = {
 			Settings: {
-				speed: {players:3, ball: 1}
+				speed: {players:15, ball: 10}
 			},
 			/**@type{Player}*/
 			PlayerLeft: {
@@ -308,7 +312,6 @@
 					let n = Game.get_player_node(this, m_cri.player);
 					NodeUtil.set_xy_vel(n, {y: dirnum*psf});
 				}
-
 			})
 
 
@@ -359,7 +362,8 @@
 				radius: 10,
 				color: 'green',
 				node_collides: true,
-				vel_x: 1
+				vel_x: 1*Game.Settings.speed.ball,
+				vel_y: 0
 			})
 
 			Game.reset_all_positions(this);

--- a/public/index.html
+++ b/public/index.html
@@ -250,6 +250,8 @@
 			return {
 				move: move_node
 			,	bounce
+			,	bounce_biased
+			,	bounce_hard
 			,	process_velocity
 			,	get_vel_xy: get_velocity
 			,	set_xy_vel: set_velocity
@@ -293,7 +295,6 @@
 			},
 			Ball: {
 				node_name: "ball-circle"
-			,	last_touched_by: null
 			},
 			/** 
 			 * Adjust both the canvas and the app to resize the game.

--- a/public/index.html
+++ b/public/index.html
@@ -64,6 +64,23 @@
 							: y_failed ? {c: "YES", reason: "Y"} 
 							: {c: "NO"});
 			}
+
+			/**
+			 * Attempt to move a node. Send back data for success or failure.
+			 * @param {AppNode} node
+			 * @param {XY_Adjustment} xyadj
+			 * @returns {{c: "MOVED"} | {c: "STAYED", reason: CollisionReason}}
+			 **/
+			function move_node(node, xyadj) {
+				let m_collision = will_node_collide(node, xyadj);
+				if(m_collision.c == "NO") {
+					node.x += (xyadj.x ?? 0);
+					node.y += (xyadj.y ?? 0);
+					return {c: "MOVED"};
+				}else{
+					return {c: "STAYED", reason: m_collision.reason};
+				}
+			}
 		});
 		/**@type{ReturnType<build_NodeUtil>}*/
 		var NodeUtil;

--- a/public/index.html
+++ b/public/index.html
@@ -59,28 +59,32 @@
 			 * @param {nodes: Array<AppNode>} app
 			 * @param {AppNode} node
 			 * @param {XY_Adjustment} xyadj
-			 * @returns {{c: "YES", reason: CollisionReason} | {c: "NO"}}
+			 * @returns {{c: "YES", detail: NodeCollisionDetail } 
+			 * | {c: "NO"}}
 			*/
 			function will_node_collide(node, xyadj) {
 				/**@type{Array<AppNode>}*/
 				let nodes = app.nodes;
 				
-				let prop_x = node.x+(xyadj.x ?? 0), prop_y = node.y+(xyadj.y ?? 0), radius = node.radius;
+				let prop_x = node.x+(xyadj.x ?? 0), prop_y = node.y+(xyadj.y ?? 0)
+					, radius = node.radius, height = node.height, width = node.width;
 				for(let x=0;x<=nodes.length;x++) {
 					let other = nodes[x];
 					if(other.id == node.id) {x++ ; continue;}
 					let min_x = other.x, max_x = min_x+other.width
-					,	min_y = other.y, max_y = min_y+other.length;
+					,	min_y = other.y, max_y = min_y+other.height;
 
-					let x_failed = prop_x+radius >= min_x && prop_x-radius <= max_x
-					,	y_failed = prop_y+radius >= min_y && prop_y-radius <= max_y;
+					let prop_width = node.width ?? radius, prop_height = node.height ?? radius;
+
+					let prop_min_x = prop_x-prop_width, prop_max_x = prop_x+prop_width
+					,	prop_min_y = prop_y-prop_height, prop_max_y = prop_y+prop_height
+
+					let x_failed = prop_max_x >= min_x && prop_min_x <= max_x
+					,	y_failed = prop_max_y >= min_y && prop_min_y <= max_y;
 
 					if(x_failed && y_failed) {
-						return {c: "YES", reason: "BOTH"};
-					}else if(x_failed) {
-						return {c: "YES", reason: "X"};
-					}else if(y_failed) {
-						return {c: "YES", reason: "Y"};
+						return {c: "YES", detail: {prop_x, prop_y, prop_min_x, prop_min_y
+							, prop_max_x, prop_max_y, min_x, min_y, max_x, max_y, other_width: other.width, other_height: other.height}};
 					}
 				}
 				return {c: "NO"};

--- a/public/index.html
+++ b/public/index.html
@@ -34,13 +34,13 @@
 			 * @typedef {"X" | "Y" | "BOTH"} CollisionReason
 			*/
 			/**
-			 * Will Collide? Check if the proposed changes to the node will cause a collision.
+			 * Will Collide with bounds? Check if the proposed changes to the node will cause a collision with the canvas bounds.
 			 * @param {{height: number, width: number}} app -- We're highlighting the pieces we pull from the app.
 			 * @param {AppNode} node
 			 * @param {XY_Adjustment} xyadj
 			 * @returns {{c: "YES", reason: CollisionReason} | {c: "NO"}}
 			 * */
-			function will_node_collide(node, xyadj) {
+			function will_bounds_collide(node, xyadj) {
 				let prop_x = node.x+(xyadj.x ?? 0), prop_y = node.y+(xyadj.y ?? 0);
 				/**@type{{width: number, height: number}}*/
 				let {width: app_x, height: app_y} = app;
@@ -56,16 +56,21 @@
 			 * Attempt to move a node. Send back data for success or failure.
 			 * @param {AppNode} node
 			 * @param {XY_Adjustment} xyadj
-			 * @returns {{c: "MOVED"} | {c: "COLLIDED", reason: CollisionReason}}
+			 * @param {boolean} check_node_collide
+			 * @returns {{c: "MOVED"} | {c: "OUT_OF_BOUNDS" | "NODE_COLLISION", reason: CollisionReason}}
 			 **/
-			function move_node(node, xyadj) {
-				let m_collision = will_node_collide(node, xyadj);
-				if(m_collision.c == "NO") {
+			function move_node(node, xyadj, check_node_collide=false) {
+				let m_outofbounds = will_bounds_collide(node, xyadj);
+				if(m_outofbounds.c == "NO") {
+					let m_node_collision = check_node_collide ? will_node_collide(node, xyadj) : {c: /**@type{"NO"}*/("NO")};
+					if(m_node_collision.c == "YES") {
+						return {c: "NODE_COLLISION", reason: m_node_collision.reason};
+					}
 					node.x += (xyadj.x ?? 0);
 					node.y += (xyadj.y ?? 0);
 					return {c: "MOVED"};
 				}else{
-					return {c: "COLLIDED", reason: m_collision.reason};
+					return {c: "OUT_OF_BOUNDS", reason: m_collision.reason};
 				}
 			}
 
@@ -324,7 +329,7 @@
 
 			for(let player_node of [Game.get_player_node(this, Game.PlayerLeft), Game.get_player_node(this, Game.PlayerRight)]) {
 				let m_pn_move = NodeUtil.process_velocity(player_node);
-				if(m_pn_move.c == "COLLIDED") {
+				if(m_pn_move.c == "OUT_OF_BOUNDS") {
 					NodeUtil.set_xy_vel(player_node, {y: 0});
 				}
 			}

--- a/public/index.html
+++ b/public/index.html
@@ -270,12 +270,12 @@
 		/**@type{ReturnType<build_NodeUtil>}*/
 		var NodeUtil;
 
-		/**@typedef {{node_name: string, score: number, player_name: string, controls: {Up: string, Down: string}}} Player*/
+		/**@typedef {{node_name: string, score: number, player_name: string, controls: {Up: string, Down: string}, score_floater_name: string}} Player*/
 
 
 		var Game = {
 			Settings: {
-				speed: {players:15, ball: 10}
+				info_text_fl: "info-text"
 			},
 			/**@type{Player}*/
 			PlayerLeft: {
@@ -286,6 +286,7 @@
 					Up: "KeyW"
 				,	Down: "KeyS"
 				}
+			,	score_floater_name: "score-left"
 			},
 			/**@type{Player}*/
 			PlayerRight: {
@@ -296,12 +297,19 @@
 					Up: "ArrowUp"
 				,	Down: "ArrowDown"
 				}
+			,	score_floater_name: "score-right"
 			},
 			/**@param {Player} player
 			 * @returns {MovingNode}
 			*/
 			get_player_node (app, player) {
 				return app.getNode(player.node_name);
+			},
+			/**@param {Player} player
+			 * @returns {Floater}
+			*/
+			get_player_score_floater(app, player) {
+				return app.getFloater(player.score_floater_name);
 			},
 			Ball: {
 				node_name: "ball-circle"
@@ -335,9 +343,51 @@
 				ball_n.x = (0.5*app.width) - half_r;
 				ball_n.y = (0.5*app.height) - half_r;
 			},
+			reset_score_positions(app) {
+				let left = Game.get_player_score_floater(app, Game.PlayerLeft);
+				let right = Game.get_player_score_floater(app, Game.PlayerRight);
+				let one_segment_x = 0.125*app.width;
+				let half_x = 0.5*app.width;
+				let margin_down = Math.max(left.font_px, right.font_px);
+				left.y = margin_down; right.y = margin_down;
+				left.x = half_x - one_segment_x - left.font_px;
+				right.x = half_x + one_segment_x;
+			},
 			reset_all_positions(app) {
 				Game.reset_player_positions(app);
 				Game.reset_ball_position(app);
+				Game.reset_score_positions(app);
+				Game.reset_info_text(app);
+			},
+			reset_scores(app) {
+				Game.PlayerLeft.score = 0;
+				Game.PlayerRight.score = 0;
+				Game.get_player_score_floater(app, Game.PlayerLeft).value = "0";
+				Game.get_player_score_floater(app, Game.PlayerRight).value = "0";
+			},
+			/**@returns {Floater} */
+			get_info_text_floater(app) {
+				return app.getFloater(Game.Settings.info_text_fl);
+			},
+			reset_info_text(app) {
+				let gitfl = Game.get_info_text_floater(app);
+				gitfl.hidden = true;
+				gitfl.value = "";
+				// let one_segment_x = 0.125*app.width;
+				let half_x = 0.5*app.width;
+				// gitfl.x = half_x - one_segment_x;
+				gitfl.x = half_x;
+				gitfl.y = app.height - gitfl.font_px;
+			},
+			show_info_text(app){
+				Game.get_info_text_floater(app).hidden = false;
+			},
+			hide_info_text(app) {
+				Game.get_info_text_floater(app).hidden = true;
+			},
+			set_info_text(app, text) {
+				Game.get_info_text_floater(app).value = text;
+			},
 			},
 			get_control_request_info(control_code) {
 				var found_player, direction;
@@ -369,10 +419,13 @@
 			// My edits to app that are not, as part of the readme instructions, permitted to be added to app.js
 
 			this.paused = false;
-			this.pause = function pause_app() {
+			this.pause = function pause_app(pause_txt = "Paused - Press Space") {
+				Game.set_info_text(this, pause_txt);
+				Game.show_info_text(this);
 				this.paused = true;
 			}
 			this.unpause = function unpause_app() {
+				Game.hide_info_text(this);
 				this.paused = false;
 			}
 			this.toggle_pause = function toggle_app_pause() {
@@ -460,9 +513,26 @@
 				node_collides: true,
 				vel_x: 1*Game.Settings.speed.ball,
 				vel_y: 0
-			})
+			});
+
+			this.floaters.push(/**@type{Floater}*/({
+				id: "score-left", align: "left", color: "black", font_px: 64, font: "Sans-Serif", type: "text"
+				, value: "0", x: 0, y: 0
+			}));
+
+			this.floaters.push(/**@type{Floater}*/({
+				id: "score-right", align: "left", color: "black", font_px: 64, font: "Sans-Serif", type: "text"
+				, value: "0", x: 0, y: 0
+			}));
+			
+			this.floaters.push(/**@type{Floater}*/({
+				id: "info-text", align: "center", color: "black", font_px: 48, font: "Sans-Serif", type: "text"
+				, value: "", x: 0, y: 0, hidden: true
+			}));
 
 			Game.reset_all_positions(this);
+			Game.set_info_text(this, "Start: Press Space.");
+			Game.show_info_text(this);
 		};
 
 		app.onUpdate = function(time){

--- a/public/index.html
+++ b/public/index.html
@@ -81,6 +81,10 @@
 					return {c: "STAYED", reason: m_collision.reason};
 				}
 			}
+			return {
+				will_collide_q : will_node_collide
+			,	move: move_node
+			}
 		});
 		/**@type{ReturnType<build_NodeUtil>}*/
 		var NodeUtil;
@@ -123,6 +127,7 @@
 		};
 
 		app.onUpdate = function(time){
+
 			// Again, not touching app.js. I'd prefer that onUpdate occur
 			// after initialization, not before it (app.js line 22 & 23 being swapped).
 			// So this is a clunky workaround that adds another boolean check to the sensitive update function. 
@@ -130,13 +135,17 @@
 			// or I could wrap app.onInit and app.onUpdate in its own init, but that would appear redundant at first glance. Consider this a TODO.
 			if(NodeUtil == undefined) return;
 
-			if(Math.cos(this.timestamp / 100) > 0){
-				this.getNode('red-box').direction = -1;
+			/**@type {MovingNode}*/
+			let red_box = this.getNode("red-box");
+			NodeUtil.move(this.getNode('black-box'), {y: 1});
+
+			if(Math.cos(this.timestamp/1000) > 0){
+				red_box.direction = -1;
 			}else{
-				this.getNode('red-box').direction = 1;
+				red_box.direction = 1;
 			}
 
-			this.getNode('red-box').x+=this.getNode('red-box').direction;
+			NodeUtil.move(red_box, {x: red_box.direction});
 		};
 	</script>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -160,9 +160,6 @@
 					, y_sign = xyadj.y > 0 ? "POS": "NEG";
 				const flip_sign = (sign) => sign == "POS" ? "NEG" : "POS";
 				let signs = {x: x_sign, y: y_sign};
-
-				console.log({x_sign, y_sign});
-
 				if(collision_reason == "BOTH") {
 					signs.x = flip_sign(x_sign); 
 					signs.y = flip_sign(y_sign);
@@ -175,7 +172,6 @@
 					x: Math.abs(xyadj.x)
 				,	y: Math.abs(xyadj.y)
 				};
-				console.log(signs);
 				const total_velocity = absv.x+absv.y;
 				// Slide {bias_strength}% of the unbiased velocity over to the biased.
 				let inv_bias = bias_axis == "x" ? "y": "x";
@@ -185,7 +181,6 @@
 				let new_biased_velocity_absv = absv[bias_axis]+shifting_velocity;
 				new_velocity[bias_axis] = new_biased_velocity_absv*(signs[bias_axis] == "POS" ? 1 : -1);
 				new_velocity[inv_bias] = (total_velocity-new_biased_velocity_absv)*(signs[inv_bias] == "POS" ? 1 : -1);
-				console.log(new_velocity)
 				return {move_result: move_node(node, new_velocity), new_velocity};
 			}
 
@@ -204,8 +199,7 @@
 				// I check where along each dimension that the ball is 'closest to' by getting its relative distance from the middle of each dim
 				// and dividing that such that I get a percentile (e.g., 27% taller, 32% shorter - represented as 27, -32 respectively)
 				// The side where the collision did not occur will typically have a larger "from middle wgt", often over 100/-100.
-				// I suspect there is a strong possibility that even the correct side can reach over 100/-100 due to
-				// the projected boundaries of the sphere not being entirely exact, but it behaves well enough that I would consider it a TODO..
+				// There are occasions where the ball strikes and both are in excess of 100/-100. We still pick the smallest and then cap the weight.
 
 				let from_middle_wgt;
 				let half_rect_height = rect_height*0.5
@@ -226,6 +220,11 @@
 				let violation_sign = (violation_current_velocity > 0) ? "POS" : violation_current_velocity < 0 ? "NEG" : "ZERO";
 
 				// The 'from_middle_wgt' determines the weight that is stolen from the total velocity.
+
+				// Sometimes it can exceed itself, so we just 'max' it out here:
+				if(from_middle_wgt > 100) from_middle_wgt = 100;
+				if(from_middle_wgt < -100) from_middle_wgt = -100;
+
 				// Since we don't want it to completely deadpan movement, it only gets a 90% share of the velocity, max.
 				let surface_axis_velocity = Math.floor(0.9*total_velocity*from_middle_wgt/10)/10;
 				// Dump the rest into the violation axis velocity & give it a flip.

--- a/public/index.html
+++ b/public/index.html
@@ -118,8 +118,8 @@
 			 * @param {MovingNode} movode 
 			 * @param {{x: number, y: number}} new_velocity */
 			function set_velocity(movode, {x,y}) {
-				movode.vel_x = x;
-				movode.vel_y = y;
+				if(x != undefined) movode.vel_x = x;
+				if(y != undefined) movode.vel_y = y;
 			}
 
 			return {
@@ -133,6 +133,42 @@
 		});
 		/**@type{ReturnType<build_NodeUtil>}*/
 		var NodeUtil;
+
+		/**@typedef {{node_name: string, score: number, player_name: string, controls: {Up: string, Down: string}}} Player*/
+
+
+		var Game = {
+			/**@type{Player}*/
+			PlayerLeft: {
+				node_name: "red-box"
+			,	score: 0
+			,	player_name: "Left"
+			,	controls: {
+					Up: "KeyW"
+				,	Down: "KeyS"
+				}
+			},
+			/**@type{Player}*/
+			PlayerRight: {
+				node_name: "black-box"
+			,	score: 0
+			,	player_name: "Right"
+			,	controls: {
+					Up: "ArrowUp"
+				,	Down: "ArrowDown"
+				}
+			},
+			/**@param {Player} player
+			 * @returns {MovingNode}
+			*/
+			get_player_node: function get_player_node(app, player) {
+				return app.getNode(player.node_name);
+			},
+			Ball: {
+				node_name: "ball-circle"
+			,	last_touched_by: null
+			}
+		}
 
 		app.onInit = function(){
 
@@ -156,11 +192,39 @@
 				if(e.code == "Space") {
 					// `this` is not the event because of how arrow functions mingle in the lexical scoping world.
 					this.toggle_pause();
+				}else if(e.code == Game.PlayerLeft.controls.Up || e.code == Game.PlayerLeft.controls.Down) {
+					let n = Game.get_player_node(this, Game.PlayerLeft);
+					NodeUtil.set_xy_vel(n, {y:0});
+				}else if(e.code == Game.PlayerRight.controls.Up || e.code == Game.PlayerRight.controls.Down) {
+					let n = Game.get_player_node(this, Game.PlayerRight);
+					NodeUtil.set_xy_vel(n, {y: 0});
 				}
 			})
 
 			document.addEventListener("keydown", (e) => {
 				if(e.repeat) return;
+				switch(e.code) {
+					case Game.PlayerLeft.controls.Up: {
+						let n = Game.get_player_node(this, Game.PlayerLeft);
+						NodeUtil.set_xy_vel(n, {y: -1});
+						break;
+					}
+					case Game.PlayerRight.controls.Up: {
+						let n = Game.get_player_node(this, Game.PlayerRight);
+						NodeUtil.set_xy_vel(n, {y: -1});
+						break;
+					}
+					case Game.PlayerLeft.controls.Down: {
+						let n = Game.get_player_node(this, Game.PlayerLeft);
+						NodeUtil.set_xy_vel(n, {y: 1});
+						break;
+					}
+					case Game.PlayerRight.controls.Down: {
+						let n = Game.get_player_node(this, Game.PlayerRight);
+						NodeUtil.set_xy_vel(n, {y: 1});
+						break;
+					}
+				}
 
 			})
 
@@ -198,7 +262,7 @@
 				width  : 25,
 				height : 100,
 				color  : 'black',
-				vel_x: 0.25,
+				vel_x: 0,
 				vel_y: 1
 			});
 		};
@@ -212,13 +276,13 @@
 			// or I could wrap app.onInit and app.onUpdate in its own init, but that would appear redundant at first glance. Consider this a TODO.
 			if(NodeUtil == undefined) return;
 			if(this.paused) return;
-			let black_box = this.getNode('black-box');
-			let m_bb_move = NodeUtil.process_velocity(black_box);
-			if(m_bb_move.c == "COLLIDED") {
-				let {new_velocity} = NodeUtil.bounce(black_box, NodeUtil.get_vel_xy(black_box), m_bb_move.reason);
-				NodeUtil.set_xy_vel(black_box, new_velocity);
-			}
 
+			for(let player_node of [Game.get_player_node(this, Game.PlayerLeft), Game.get_player_node(this, Game.PlayerRight)]) {
+				let m_pn_move = NodeUtil.process_velocity(player_node);
+				if(m_pn_move.c == "COLLIDED") {
+					NodeUtil.set_xy_vel(player_node, {y: 0});
+				}
+			}
 
 			/**@type {MovingNode}*/
 			let red_box = this.getNode("red-box");

--- a/public/index.html
+++ b/public/index.html
@@ -160,39 +160,12 @@
 
 				let total_velocity = Math.abs(moving_circle.vel_x)+Math.abs(moving_circle.vel_y);
 
-				// Most of the time, it's the y surface we're bouncing on. We determine by checking which violation is closest to the ball.
-				// The primary surface is the opposite of that violation's axis.
-				// E.g., if we're within 2 points of violating the x axis, that means we'd be striking the surface on the y axis.
-				// This only works assuming this is a collision against a rectangle.
-
-				/**@type{Array<{value: number} & {surface: "Y", violation_axis: "X"} | {surface: "X", violation_axis: "Y"}}*/
-				// let minlist = [
-				// 		{surface: "Y", violation_axis: "X", value: Math.abs(max_x-x)}
-				// 	,	{surface: "Y", violation_axis: "X", value: Math.abs(min_x-x)}
-				// 	,	{surface: "X", violation_axis: "Y", value: Math.abs(max_y-y)}
-				// 	,	{surface: "X", violation_axis: "Y", value: Math.abs(min_y-y)}
-				// ];
-
-				// "closest" here stands for "closest to the current position". We want to know where the circle is closest to.
-				// let closest = minlist.reduce((prev, curr) => curr.value < prev.value ? curr : prev);
-
-				// Determine the 'weight' for the primary surface in each direction from the middle. Ranges from -100 to 100.
-				// /**@type{number}*/
-				// let from_middle_wgt;
-				// /**@type{number}*/
-				// let violation_current_velocity;
-				// // Most common case.
-				// if(closest.surface == "Y") {
-				// 	let half_rect_height = rect_height*0.5
-				// 	console.log({half_rect_height, y, min_y});
-				// 	from_middle_wgt = Math.ceil(100/half_rect_height*(y-half_rect_height-min_y));
-				// 	violation_current_velocity = moving_circle.vel_x;
-				// } else {
-				// 	let half_rect_width = rect_width*0.5;
-				// 	console.log({half_rect_width, x, min_x});
-				// 	from_middle_wgt = Math.ceil(100/half_rect_width*(x-half_rect_width-min_x));
-				// 	violation_current_velocity = moving_circle.vel_y;
-				// }
+				// In order to attempt to simulate an actual ping pong paddle whacking the ball at an angle,
+				// I check where along each dimension that the ball is 'closest to' by getting its relative distance from the middle of each dim
+				// and dividing that such that I get a percentile (e.g., 27% taller, 32% shorter - represented as 27, -32 respectively)
+				// The side where the collision did not occur will typically have a larger "from middle wgt", often over 100/-100.
+				// I suspect there is a strong possibility that even the correct side can reach over 100/-100 due to
+				// the projected boundaries of the sphere not being entirely exact, but it behaves well enough that I would consider it a TODO..
 
 				let from_middle_wgt;
 				let half_rect_height = rect_height*0.5

--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,28 @@
 		}
 		var build_NodeUtil = ((app) => {
 
+			/**
+			 * @typedef {{x: number | undefined, y: number | undefined}} XY_Adjustment -- X & Y adjustments proposed. For ease of use, undeclared=0.
+			 * @typedef {"X" | "Y" | "BOTH"} CollisionReason
+			*/
+			/**
+			 * Will Collide? Check if the proposed changes to the node will cause a collision.
+			 * @param {{height: number, width: number}} app -- We're highlighting the pieces we pull from the app.
+			 * @param {AppNode} node
+			 * @param {XY_Adjustment} xyadj
+			 * @returns {{c: "YES", reason: CollisionReason} | {c: "NO"}}
+			 * */
+			function will_node_collide(node, xyadj) {
+				let prop_x = node.x+(xyadj.x ?? 0), prop_y = node.y+(xyadj.y ?? 0);
+				/**@type{{width: number, height: number}}*/
+				let {width: app_x, height: app_y} = app;
+				let x_failed = (prop_x < 0 || prop_x+node.width > app_x)
+				, 	y_failed = (prop_y < 0 || prop_y+node.height > app_y);
+				return (x_failed && y_failed ? {c: "YES", reason: "BOTH"} 
+							: x_failed ? {c: "YES", reason: "X"} 
+							: y_failed ? {c: "YES", reason: "Y"} 
+							: {c: "NO"});
+			}
 		});
 		/**@type{ReturnType<build_NodeUtil>}*/
 		var NodeUtil;

--- a/public/index.html
+++ b/public/index.html
@@ -78,8 +78,42 @@
 					node.y += (xyadj.y ?? 0);
 					return {c: "MOVED"};
 				}else{
-					return {c: "STAYED", reason: m_collision.reason};
+					return {c: "COLLIDED", reason: m_collision.reason};
 				}
+			}
+
+
+			/**
+			 * Move based on "velocity".
+			 * @param {MovingNode} movode
+			 **/
+			function process_velocity(movode) {
+				let {vel_x, vel_y} = movode;
+				if(vel_x == 0 && vel_y == 0) return {c: /**@type{"STATIONARY"}*/("STATIONARY")};
+
+				return move_node(movode, {x: vel_x, y: vel_y});
+				// For an interesting idea later, have a 'resistance' property that proposes a new momentum/velocity if force (keypress) isn't being applied anymore?
+			}
+
+			/**
+			 * Create a movement using the 'velocity' from the attempted xyadj
+			 * by 'bouncing' where the collision was detected.
+			 * @param {AppNode} node
+			 * @param {XY_Adjustment} xyadj
+			 * @param {CollisionReason} collision_reason
+			 * */
+			function bounce(node, xyadj, collision_reason) {
+				let new_x = collision_reason == "BOTH" || collision_reason == "X" ? -xyadj.x : xyadj.x,
+					new_y = collision_reason == "BOTH" || collision_reason == "Y" ? -xyadj.y : xyadj.y;
+				let new_velocity = {x: new_x, y: new_y};
+				return {move_result: move_node(node, new_velocity), new_velocity};
+			}
+
+			/**
+			 * @param {MovingNode} movode */
+			function get_velocity(movode) {
+				return {x: movode.vel_x, y: movode.vel_y};
+			}
 			}
 			return {
 				will_collide_q : will_node_collide

--- a/public/index.html
+++ b/public/index.html
@@ -70,7 +70,7 @@
 					node.y += (xyadj.y ?? 0);
 					return {c: "MOVED"};
 				}else{
-					return {c: "OUT_OF_BOUNDS", reason: m_collision.reason};
+					return {c: "OUT_OF_BOUNDS", reason: m_outofbounds.reason};
 				}
 			}
 

--- a/public/index.html
+++ b/public/index.html
@@ -27,19 +27,6 @@
 		 * */
 
 
-		/** 
-		 * Adjust both the canvas and the app to resize the game.
-		 * @param {{height: number, width: number, clear: ()=>void}} app
-		 * @param {number} width
-		 * @param {number} height
-		 **/
-		function resize_game(app, height, width) {
-			document.getElementById("canvas").height = height;
-			document.getElementById("canvas").width = width;
-			app.height = height; app.width = width;
-			app.clear();
-			// TODO: adjust app nodes accordingly.
-		}
 		var build_NodeUtil = ((app) => {
 
 			/**
@@ -167,6 +154,19 @@
 			Ball: {
 				node_name: "ball-circle"
 			,	last_touched_by: null
+			},
+			/** 
+			 * Adjust both the canvas and the app to resize the game.
+			 * @param {{height: number, width: number, clear: ()=>void}} app
+			 * @param {number} width
+			 * @param {number} height
+			 **/
+			resize(app, height, width) {
+				document.getElementById("canvas").height = height;
+				document.getElementById("canvas").width = width;
+				app.height = height; app.width = width;
+				app.clear();
+				// TODO: adjust app nodes accordingly.
 			}
 		}
 

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,8 @@
 
 		/**
 		 * @typedef {{id: string, x: number, y: number
-		 * , color: string}  & ({shape: "Rectangle", width: number, height: number} | {shape: "Circle", radius: number} )} AppNode
+		 * , color: string, node_collides: boolean}  
+		 * & ({shape: "Rectangle", width: number, height: number} | {shape: "Circle", radius: number} )} AppNode
 		 * @typedef {AppNode & {vel_x: number, vel_y: number}} MovingNode
 		 * */
 
@@ -92,10 +93,10 @@
 			 * @param {boolean} check_node_collide
 			 * @returns {{c: "MOVED"} | {c: "OUT_OF_BOUNDS" | "NODE_COLLISION", reason: CollisionReason}}
 			 **/
-			function move_node(node, xyadj, check_node_collide=false) {
+			function move_node(node, xyadj) {
 				let m_outofbounds = will_bounds_collide(node, xyadj);
 				if(m_outofbounds.c == "NO") {
-					let m_node_collision = check_node_collide ? will_node_collide(node, xyadj) : {c: /**@type{"NO"}*/("NO")};
+					let m_node_collision = node.node_collides ? will_node_collide(node, xyadj) : {c: /**@type{"NO"}*/("NO")};
 					if(m_node_collision.c == "YES") {
 						return {c: "NODE_COLLISION", reason: m_node_collision.reason};
 					}
@@ -324,6 +325,7 @@
 				width  : 25,
 				height : 100,
 				color  : 'red',
+				node_collides: false,
 				direction : 0
 			});
 
@@ -334,6 +336,7 @@
 				width  : 25,
 				height : 100,
 				color  : 'black',
+				node_collides: false,
 				// vel_x: 0,
 				// vel_y: 1
 			});
@@ -344,7 +347,9 @@
 				y: 100,
 				shape: "Circle",
 				radius: 10,
-				color: 'green'
+				color: 'green',
+				node_collides: true,
+				vel_x: 1
 			})
 
 			Game.reset_all_positions(this);
@@ -366,6 +371,17 @@
 					NodeUtil.set_xy_vel(player_node, {y: 0});
 				}
 			}
+
+			/**@type {MovingNode} */
+			let ball_n = app.getNode(Game.Ball.node_name);
+			let m_ball_move = NodeUtil.process_velocity(ball_n, true);
+			if(m_ball_move.c == "NODE_COLLISION"){
+				let {new_velocity} = NodeUtil.bounce(ball_n, NodeUtil.get_vel_xy(ball_n), m_ball_move.reason);
+				NodeUtil.set_xy_vel(ball_n, new_velocity);
+			}else if(m_ball_move.c == "OUT_OF_BOUNDS") {
+				Game.reset_ball_position();
+			}
+
 		};
 	</script>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -123,7 +123,12 @@
 		};
 
 		app.onUpdate = function(time){
-			this.getNode('black-box').y++;
+			// Again, not touching app.js. I'd prefer that onUpdate occur
+			// after initialization, not before it (app.js line 22 & 23 being swapped).
+			// So this is a clunky workaround that adds another boolean check to the sensitive update function. 
+			// I could fall back to global variable assumptions (easiest, but not the best for long-term if there's more work to be done in app.onInit)
+			// or I could wrap app.onInit and app.onUpdate in its own init, but that would appear redundant at first glance. Consider this a TODO.
+			if(NodeUtil == undefined) return;
 
 			if(Math.cos(this.timestamp / 100) > 0){
 				this.getNode('red-box').direction = -1;

--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,12 @@
 		const BODY_MARGIN = 10;
 		document.querySelector("body").style.margin = BODY_MARGIN+"px";
 
+		/**
+		 * @typedef {{id: string, x: number, y: number, width: number
+		 * , height: number, color: string}} AppNode
+		 * @typedef {AppNode & {traj_x: number, traj_y: number}} MovingNode
+		 * */
+
 
 		/** 
 		 * Adjust both the canvas and the app to resize the game.

--- a/public/index.html
+++ b/public/index.html
@@ -474,6 +474,15 @@
 				this.paused ? this.unpause() : this.pause();
 			}
 
+			this.reset = function reset_app() {
+				this.pause();
+				Game.reset_scores(this);
+				Game.reset_all_positions(this);
+				Game.reset_ball_velocity(this);
+				Game.set_info_text(this, "Start: Press Space.");
+				Game.show_info_text(this);
+			}
+
 			// Edits to app end.
 
 			document.addEventListener("keyup", (e) => {

--- a/public/index.html
+++ b/public/index.html
@@ -136,6 +136,36 @@
 
 		app.onInit = function(){
 
+
+			// My edits to app that are not, as part of the readme instructions, permitted to be added to app.js
+
+			this.paused = false;
+			this.pause = function pause_app() {
+				this.paused = true;
+			}
+			this.unpause = function unpause_app() {
+				this.paused = false;
+			}
+			this.toggle_pause = function toggle_app_pause() {
+				this.paused ? this.unpause() : this.pause();
+			}
+
+			// Edits to app end.
+
+			document.addEventListener("keyup", (e) => {
+				if(e.code == "Space") {
+					// `this` is not the event because of how arrow functions mingle in the lexical scoping world.
+					this.toggle_pause();
+				}
+			})
+
+			document.addEventListener("keydown", (e) => {
+				if(e.repeat) return;
+
+			})
+
+
+
 			// Call to update canvas/app to new size. Declared here to lock in app as `this` to the scope.
 			// We're also only using this once elsewhere, in the below event declaration.
 			let update_size_to_viewport = () => resize_game(this, window.visualViewport.height-BODY_MARGIN, window.visualViewport.width-BODY_MARGIN);

--- a/public/index.html
+++ b/public/index.html
@@ -52,6 +52,39 @@
 							: {c: "NO"});
 			}
 
+
+			/**
+			 * Will we collide with another node?
+			 * @param {nodes: Array<AppNode>} app
+			 * @param {AppNode} node
+			 * @param {XY_Adjustment} xyadj
+			 * @returns {{c: "YES", reason: CollisionReason} | {c: "NO"}}
+			*/
+			function will_node_collide(node, xyadj) {
+				/**@type{Array<AppNode>}*/
+				let nodes = app.nodes;
+				
+				let prop_x = node.x+(xyadj.x ?? 0), prop_y = node.y+(xyadj.y ?? 0), radius = node.radius;
+				for(let x=0;x<=nodes.length;x++) {
+					let other = nodes[x];
+					if(other.id == node.id) {x++ ; continue;}
+					let min_x = other.x, max_x = min_x+other.width
+					,	min_y = other.y, max_y = min_y+other.length;
+
+					let x_failed = prop_x+radius >= min_x && prop_x-radius <= max_x
+					,	y_failed = prop_y+radius >= min_y && prop_y-radius <= max_y;
+
+					if(x_failed && y_failed) {
+						return {c: "YES", reason: "BOTH"};
+					}else if(x_failed) {
+						return {c: "YES", reason: "X"};
+					}else if(y_failed) {
+						return {c: "YES", reason: "Y"};
+					}
+				}
+				return {c: "NO"};
+			}
+
 			/**
 			 * Attempt to move a node. Send back data for success or failure.
 			 * @param {AppNode} node

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -37,10 +37,20 @@ var app = {
 		this.onUpdate(dt);
 
 		for(var index in this.nodes){
-			var node = this.nodes[index];
 
+			var node = this.nodes[index];
+			// Assume rectangle by default
 			this.context.fillStyle = node.color;
-			this.context.fillRect(node.x, node.y, node.width, node.height);
+			if(node.shape == "Circle") {
+				this.context.beginPath();
+				this.context.arc(node.x, node.y, node.radius, 0, 2 * Math.PI);
+				this.context.stroke();
+				this.context.fill();
+				this.context.closePath();
+			}else{
+				this.context.fillRect(node.x, node.y, node.width, node.height);
+			}
+			
 		}
 
 		this.lastUpdate = Date.now();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,3 +1,5 @@
+/**@typedef {{id: string, x: number, y: number, type: "text", value: string, hidden: boolean, font: string, font_px: number, color: string, align: "left" | "center" | "right"}} Floater */
+
 var app = {
 	//initial variables
 	canvas  : null,
@@ -9,6 +11,11 @@ var app = {
 
 	//nodes
 	nodes   : [],
+
+	// Like nodes, but don't interact with the game (no collision checks with nodes, etc)
+	// They 'float' atop it.
+	/**@type{Array<Floater>} */
+	floaters	: [],
 
 	//timing
 	timestamp  : 0,
@@ -53,6 +60,18 @@ var app = {
 			
 		}
 
+		for (var index in this.floaters) {
+			/**@type{Floater} */
+			let floater = this.floaters[index];
+
+			if(floater.type == "text" && !floater.hidden) {
+				this.context.fillStyle = floater.color;
+				this.context.textAlign = floater.align;
+				this.context.font = floater.font_px+"px "+floater.font;
+				this.context.fillText(floater.value, floater.x, floater.y);
+			}
+		}
+
 		this.lastUpdate = Date.now();
 		this.timestamp+=dt;
 	},
@@ -67,7 +86,9 @@ var app = {
 
 		return { x : null, y : null, width : null, height : null };
 	},
-
+	getFloater (id) {
+		return this.floaters.find(f=>f.id==id) ?? /**@type{Floater}*/({x: null, y: null, value: null, align: "left", font_px: 12, font: "Arial", color: "black", type: "text"})
+	},
 	//events
 	onInit   : function(){},
 	onUpdate : function(){}


### PR DESCRIPTION
### Summary

Implements the game Pong. Pong permits two players to control vertically sliding 'paddles' on opposite ends of the screen. A ball is released in the center and begins heading toward one side where the player must intercept the ball with their paddle before letting it pass behind their boundary. When the ball connects with the paddle, it shifts direction away from the point of impact to threaten the opposite side's player. A player who does not intercept the ball and lets it pass through their guarded boundary is considered the loser of the round, awarding one point to the other player. The ball is released again in the center, and the cycle continues.

What went into creating Pong mechanically was:

- Fullscreen and Game Resizing
> Allowing the app to run fullscreen regardless of how the user has their browser in size.
- Movement of Nodes by Velocity
> Calculating the movement of nodes based on their current velocity (trajectory & speed).
- Player Controls
> Permitting two players to play the game separately and smoothly.
- Collision Detection
> Detecting when moving nodes are about to strike a boundary or one another.
- Collision Resolution
> Determining where a node moves after colliding.

Additionally, there were restrictions/requirements on my implementation:
- Outside of adding text drawing functionality, the display engine located in app.js could not be modified.
- `SPACE` should initiate the game and every round, as well as pause the game.
- The game could only be kicked off/run by app.onInit and app.onUpdate.

I will also note that I intentionally did not research other implementations of Pong, to simulate this being an original idea. Thus, the game code - particularly the logic for handling collision detection and resolution, where the bulk of my time was spent - is built from scratch.

### Fullscreen and Game Resizing

Fullscreen was simple to create, however slightly unintuitive. In the first attempt by simply expanding the canvas to viewport height (`window.visualViewport` is the browser's internal mechanism of tracking the size of the user's browser window), I encountered the issue that the browser thinks it should supply scrollbars once its contents have reached its own size. I was not confident that picking an arbitrary padding/margin from the canvas to the body would be enough on its own, so I followed some online suggestions to add `overflow: hidden;` to the body. This is shown in 15dc003 and some quick automation for resizing was thrown in 970a37e 's function coupled with the event listener in 7e1b16b. `window` already has a built in `resize` listener that I added to.

The function was later added to the 'Game' object as Game.resize in 72a4e8d. Major functionality didn't change until the Game engine had expanded. In 16e0b3f, resize now interacts with the Game itself by killing the current round when the window is resized and resetting the positions. This was chosen as (what I saw as) a simpler alternative to running the same game but scaling the elements of the game whenever the screen would be resized. If there is a clean solution to such a scaling adjust, particularly midway through the game, I'd be most interested in learning and implementing it, as my cursory searches online didn't draw much in the avenue of simple.

The simplicity did come at a cost, however. Because I'm effectively changing the landscape of the game each time the window scales, the rules didn't catch up to compensate. While not perfect, I created an approximate scaling of the most sensitive rules (speed of players/ball & the x-axis bias on wall collisions) in 9be8d35. In here, I effectively try to find the percentile diff between the new and old resolutions and apply them to the settings that matter. Width determines how long the game board is, so a faster ball is more appropriate in a wider game. A tall height for the game means that a ball bouncing up and down will take considerably longer to cross the board, so with the bounce_biased function, we're able to coerce each collision to heading more horizontally. If we do this far too much, the bouncing is unpredictable. If it's too little, then it behaves poorly as mentioned. So scaling the amount of bias to increase with the height helps keep the ball from spending too much time going up and down.

### Movement of Nodes by Velocity

As movement began to be added as a function in the Game engine that automatically checked collision, it occurred to me that the x++, y++ method could be replaced by storing a node's current speed and parsing that speed out into movement each update. This was initially called trajectory ebd1488, but the term quickly became velocity dc861e5. After that commit, it has effectively remained the same, but it remains as a basis for understanding how the collision resolutions are impacting the game.

A velocity of x+1, y-1 means simply that the node's x will +=1 and its y will -=1 each frame. We control any direction in the 2D space this way. I am certain that there is a better method using radians/degrees, but for the purposes of a demo, I kept it in more comprehensible terms at a glance. 

If I were to continue production of this game, it is likely that this would be one of the first major changes. I would thereby separate out velocity into its two component parts: direction and speed. Direction in radians, speed determined by settings. It would be considerably easier to play with velocity this way. In hindsight, it would make some of the boggling calculations and bugs squashed in collision resolutions to be entirely unnecessary.

### Player Controls

I built controls based heavily on this mdn entry and its recommendations at the bottom (https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code), particularly "There are several ways this code can be made better. Most real games would watch for keydown events, start motion when that happens, and stop the motion when the corresponding keyup occurs, instead of relying on key repeats. That would allow both smoother and faster movement, but would also allow the player to be moving and steering at the same time."

Implementing that also meant ignoring the key being held down and firing repeat keydown events, which we do ignore by skipping if e.repeat is true. Little has changed regarding this from this commit, 3b34373, as it's been acting smoothly (though do take a look at Known Bugs at the end in regard to framerate...) 

### Collision Detection

There are two collision detection functions in the game, one to check for boundaries, the other to check for other nodes. They share some strong similarities:

The collision is detected by looking at the node's _proposed_ new position, not its current position. No actual change is made to state in order for these checks to be run, keeping them pure. 

The proposed position fails its checks and is considered collided if the proposal leaves anywhere of the object within the confines of another object or past a boundary, depending on which function it is.

I return information regarding the collision so that it can be parsed elsewhere, particularly by the collision resolvers. I detail the type of collision encountered so that game logic can make informed decisions without needing to recalculate anything. Preventing recalculation justifies the cost of sending json vs a boolean as a response.

Note: Collision detection does have a flaw in that circular nodes, for purposes of collision are just squares with a length of diameter. Also note that I don't ever use diameter in the code, only the radius. A rectangle's 0,0 point is the top left of the rectangle, but a circle's is its center. So for me to know, say, the furthest position x that a particular node reaches, then for a rectangle it's point_x + width, but for a circle, it's point_x + radius, as it only needs to cover the other half of the circle to reach any extremity.

### Collision Resolution

The bulk of my time spent on this project was spent in collision resolution. As I disclaimed in the summary, I could've shaved many hours off programming if I had yanked collision logic from elsewhere, but I'd rather you be able to see what I design under great unknowns (also, I enjoy a challenge that boggles my head).

The collision system is far from perfect, so it had multiple variations appear. It began with a simple bounce (85daf52) that deflected the incoming direction. This was 'too good' - such that I was actually able to get the ball locked bouncing up and down between wall and paddle.

So the next idea was `bounce_hard` 4be1a91, which took several iterations. The last two can be seen in this commit, one commented, one not. The commit describes it in great detail. The idea is fairly simple, though: find out where you hit what surface, and based on how far you are way from the center of that surface, adjust trajectory with increasing change. 

The problem was in finding out exactly what surface I hit. Because in order to 'collide' with something, I need to violate both of its internal planes. Eventually, I decided to simply check both planes to see how far off the ball was from their respective axis, in a percentile. -100 to 100, where 100 meant the furthest end of one of the planes, and -100 was the other end, effectively the relative zero. 0 in the percentile meant the ball struck at exactly the center of that plane. So the plane the ball actually hit will have a value contained in 100/-100, whereas the plane the ball did not hit would have the ball in excess of 100/-100. So I simply chose the lower one.

But trouble came as a bug when a collision occurred somewhere odd, like a corner. Turns out there's a case - perhaps due to a fault in the collision logic or somewhere else I've yet to find - where the ball could be in excess of 100/-100 for both planes. What that meant was the ball will gain some new velocity, as I use 100/-100 for the weighted adjustment to the velocity. This was "fixed" (patched) by simply bringing the excess weight back down to 100 or -100.

With `bounce_hard` implemented, the ball no longer locked itself in a perfect cadence. It flung in all sorts of ways, but, most importantly, in a manner a player could mostly predict. 

I had another issue, though, and that was that the 'perfect' collision of `bounce` was still being run on the walls. The walls should be incredibly reliable, far more than the paddle, as both players are trying to aim with it. Furthermore, `bounce_hard`'s logic was incredibly dependent on node<=>node collision, not node<=>boundary. So I needed something new. The biggest issue was that the bouncing, once reaching an incredibly high Y lean, would take ages to bounce up and down across the screen. Even if it were 'realistic', it's certainly not fun by any stretch. So `bounce_biased` was born (f0f57ed).

The purpose of `bounce_biased` was to introduce a forced lean in one direction. Other than that, it was effectively a clone of `bounce`'s core logic. What's effectively done is that once `bounce_biased` is handed an axis to be biased on, it'll steal some of the direction from the other axis before finishing the bounce calculation. The degree of theft is controlled by `bias_strength`, which represents the fraction of the steal. By default, 10, 1/10th of the direction is shifted from unbiased to biased.

With that in place, the ball would now traverse much more of the x axis between bounces against boundaries, keeping the game engaging.


### A note on the drawn text
In order to get text to work, I implemented a new part of app.js called floaters.

ce5a209 and 64ba08b briefly explain the concept, considerations, and implementation put into floaters. While it would seem a worthy topic on par with player controls, especially being a feature that's dotted across the (bonus) requirements, there isn't much more to add than what the commits provide.


### Known Bugs

The game's speed can vary, I think perhaps due to the way the app.js engine runs, grabbing frames. This means that if I'm getting more frames sometimes, the game will run much faster, meaning the controls are all faster & the ball is faster. A sudden spike in difficulty that would likely need to be controlled by some sort of FPS monitor. 

The ball sometimes gets caught inside of a pong paddle. The solution to this is likely to add node<=>node collision detection to the paddles as well, simply preventing them from moving further down/up when the ball is in their way.
